### PR TITLE
Add AlgoWay to Automated Order Execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@
 ### Closed Source
 - [3Commas](https://3commas.io/) - *Can receive TV alerts and connect them to their bots to execute simple orders on crypto exchanges.*
 - [Alertatron](https://alertatron.com/) - *A service that allows you to relay TradingView alerts to Telegram, Discord, Slack, Email or webhooks, with a chart snapshot attached.*
+- [AlgoWay](https://algoway.trade/) - *TradingView webhook automation for MT5, cTrader, TradeLocker, MatchTrader, DxTrade, Capital.com, OANDA, Forex.com, IBKR, Binance, OKX, Bybit and other execution platforms.*
 - [Altrady](https://www.altrady.com/features/signal-bot) - *You can run pine script strategies on TradingView that will automatically open positions based on the signal. *
 - [AutoView](https://autoview.with.pink/) - *Free For Testnets! Google Chrome extension that receives TV alerts and relays orders to crypto exchanges.*
 - [Capitalise.ai](https://capitalise.ai/) - *Code Free Trading Automation that accepts simple [TV Webhook Automation](https://support.capitalise.ai/en/articles/5638761-using-tradingview-alerts-to-trigger-strategies)*


### PR DESCRIPTION
Adds AlgoWay to the Automated Order Execution section. AlgoWay connects TradingView webhook alerts to multiple execution platforms, including MT5, cTrader, TradeLocker, MatchTrader, DXtrade, Capital.com, IBKR, Binance, OKX, Bybit and other supported platforms.